### PR TITLE
Configure automatic issue type assignment for templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,6 +2,7 @@ name: 🐛 Bug Report
 description: Report a bug or issue with the Rise Gaming Takistan Life server
 title: "[BUG] "
 labels: ["bug", "needs-triage"]
+issue_type: 16963627
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,6 +2,7 @@ name: 🚀 Feature Request
 description: Suggest a new feature or enhancement for Rise Gaming Takistan Life
 title: "[FEATURE] "
 labels: ["feature-request", "needs-review"]
+issue_type: 16963631
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/general-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/general-suggestion.yml
@@ -2,6 +2,7 @@ name: 💡 General Suggestion
 description: Share ideas for server improvements, events, or community enhancements
 title: "[SUGGESTION] "
 labels: ["suggestion", "needs-review"]
+issue_type: 16963624
 assignees: []
 
 body:


### PR DESCRIPTION
## Summary
Configure issue templates to automatically assign appropriate GitHub organization issue types when issues are created.

## Changes Made
- ✅ **Feature Request Template** → Automatically assigned **Feature** issue type (ID: 16963631)
- ✅ **Bug Report Template** → Automatically assigned **Bug** issue type (ID: 16963627)  
- ✅ **General Suggestion Template** → Automatically assigned **Task** issue type (ID: 16963624)

## Benefits
- **Automatic Classification** - Issues are properly categorized without manual intervention
- **Consistent Organization** - All feedback aligns with RiseGaming's issue type system
- **Better Triage** - Team can quickly identify and prioritize different types of feedback
- **Professional Workflow** - Matches enterprise GitHub organization standards

## Testing
- [x] Templates maintain existing functionality
- [x] Issue type IDs verified against RiseGaming organization settings
- [x] Labels and other template features preserved

## Integration
This integrates with the existing RiseGaming organization issue types:
- **Feature** (Blue) - "A request, idea, or new functionality" 
- **Bug** (Red) - "An unexpected problem or behavior"
- **Task** (Yellow) - "A specific piece of work" (used for general suggestions)

🤖 Generated with [Claude Code](https://claude.ai/code)