### PR TITLE
Fix issue templates not displaying

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 🎮 Join Our Discord Server
     url: https://discord.gg/dVWvxEZJBj


### PR DESCRIPTION
## Summary
- Fixed issue templates not showing up in the GitHub issue creation interface
- Changed `blank_issues_enabled: false` to `blank_issues_enabled: true` in `.github/ISSUE_TEMPLATE/config.yml`

## Test plan
- [ ] Verify issue templates now appear in the "New issue" dropdown on GitHub
- [ ] Confirm all existing templates (feature-request, bug-report, general-suggestion) are accessible
- [ ] Ensure contact links still display properly

🤖 Generated with [Claude Code](https://claude.ai/code)